### PR TITLE
Add projects related to ChatGLM-6B

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Related links:
 - Deploying ChatGLM on Modelz: [tensorchord/modelz-ChatGLM](https://github.com/tensorchord/modelz-ChatGLM)
 - Docker image with built-on playground UI and streaming API compatible with OpenAI, using [Basaran](https://github.com/hyperonym/basaran): [peakji92/chatglm:6b](https://hub.docker.com/r/peakji92/chatglm/tags)
 
-- 
 Tags: F
 
 ## [bigscience-workshop/xmtf](https://github.com/bigscience-workshop/xmtf)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,16 @@ Tags: F
 
 ChatGLM-6B is an open bilingual language model based on General Language Model (GLM) framework, with 6.2 billion parameters. With the quantization technique, users can deploy locally on consumer-grade graphics cards (only 6GB of GPU memory is required at the INT4 quantization level).
 
-Tags: M
+Related links:
+
+- Alternative Web UI: [Akegarasu/ChatGLM-webui](https://github.com/Akegarasu/ChatGLM-webui)
+- Slim version (remove 20K image tokens to reduce memory usage): [silver/chatglm-6b-slim](https://huggingface.co/silver/chatglm-6b-slim)
+- Fintune ChatGLM-6b using low-rank adaptation (LoRA): [lich99/ChatGLM-finetune-LoRA](https://github.com/lich99/ChatGLM-finetune-LoRA)
+- Deploying ChatGLM on Modelz: [tensorchord/modelz-ChatGLM](https://github.com/tensorchord/modelz-ChatGLM)
+- Docker image with built-on playground UI and streaming API compatible with OpenAI, using [Basaran](https://github.com/hyperonym/basaran): [peakji92/chatglm:6b](https://hub.docker.com/r/peakji92/chatglm/tags)
+
+- 
+Tags: F
 
 ## [bigscience-workshop/xmtf](https://github.com/bigscience-workshop/xmtf)
 


### PR DESCRIPTION
Including a docker image with built-in Web UI and API endpoint, should make ChatGLM-6B qualify for F(Full) tag.