### PR TITLE
Add trlx

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ Tags: B
 
 # The list
 
-## [carperai/trlx](https://github.com/carperai/trlx)
-
- A repo for distributed training of language models with Reinforcement Learning via Human Feedback (RLHF), supporting online RL up to 20b params and offline RL to larger models. Basically what you would use to finetune GPT into ChatGPT. 
-
- Tags: B
-
 ## [lucidrains/PaLM-rlhf-pytorch](https://github.com/lucidrains/PaLM-rlhf-pytorch)
 
 Implementation of RLHF (Reinforcement Learning with Human Feedback) on top of the PaLM architecture. Basically ChatGPT but with PaLM
@@ -113,3 +107,9 @@ Related links:
 - [bigscience/mt0-base](https://huggingface.co/bigscience/mt0-base)
 
 Tags: M
+
+## [carperai/trlx](https://github.com/carperai/trlx)
+
+ A repo for distributed training of language models with Reinforcement Learning via Human Feedback (RLHF), supporting online RL up to 20b params and offline RL to larger models. Basically what you would use to finetune GPT into ChatGPT. 
+
+ Tags: B

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Tags: B
 
 # The list
 
+## [carperai/trlx](https://github.com/carperai/trlx)
+
+ A repo for distributed training of language models with Reinforcement Learning via Human Feedback (RLHF), supporting online RL up to 20b params and offline RL to larger models. Basically what you would use to finetune GPT into ChatGPT. 
+
+ Tags: B
+
 ## [lucidrains/PaLM-rlhf-pytorch](https://github.com/lucidrains/PaLM-rlhf-pytorch)
 
 Implementation of RLHF (Reinforcement Learning with Human Feedback) on top of the PaLM architecture. Basically ChatGPT but with PaLM


### PR DESCRIPTION
Add a link to [carperai/trlx](https://github.com/carperai/trlx), a repo for distributed training of language models with Reinforcement Learning via Human Feedback (RLHF)

